### PR TITLE
Fix lang attribute

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">


### PR DESCRIPTION
## Summary
- set default language to `en` in frontend

## Testing
- `npm run lint` *(fails: 'props' is assigned a value but never used, Component name "Spinner" should always be multi-word)*

------
https://chatgpt.com/codex/tasks/task_b_68848d6320188331ad50f203ea2e751c