### PR TITLE
Add configurable CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVE
 SECRET_KEY=your_super_secret_key_32_chars_long_replace_me
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+BACKEND_CORS_ORIGINS=*
 
 # Frontend (Vue) Settings
 VITE_API_BASE_URL=http://localhost:8000

--- a/.env.example.ini
+++ b/.env.example.ini
@@ -9,6 +9,7 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVE
 SECRET_KEY=your_super_secret_key_32_chars_long # Замените на сгенерированный ключ (openssl rand -hex 32)
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+BACKEND_CORS_ORIGINS=*
 
 # Frontend (Vue) Settings
 VITE_API_BASE_URL=http://localhost:8000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,6 +16,9 @@ class Settings(BaseSettings):
     # Настройки базы данных
     DATABASE_URL: str = os.getenv("DATABASE_URL", "")
 
+    # CORS settings
+    BACKEND_CORS_ORIGINS: list[str] = [origin.strip() for origin in os.getenv("BACKEND_CORS_ORIGINS", "*").split(",") if origin]
+
     # Настройки безопасности
     SECRET_KEY: str
     ALGORITHM: str = "HS256"


### PR DESCRIPTION
## Summary
- support BACKEND_CORS_ORIGINS setting with default ["*"]
- document BACKEND_CORS_ORIGINS in env examples

## Testing
- `pytest -q`
- `python -m py_compile backend/app/core/config.py backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_b_688492b677088331a823dcb77aacc365