### PR TITLE
Improve startup DB initialization

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,13 +1,10 @@
 from typing import Generator
+
+from sqlalchemy.orm import Session
+
 from app.db.session import SessionLocal
 
-def get_db() -> Generator:
-    """
-    Зависимость (dependency), которая предоставляет сессию базы данных для одного запроса.
-    Гарантирует, что сессия будет закрыта после выполнения запроса.
-    """
-    try:
-        db = SessionLocal()
+def get_db() -> Generator[Session, None, None]:
+    """Provide a transactional database session."""
+    with SessionLocal() as db:
         yield db
-    finally:
-        db.close()

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -2,12 +2,12 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from app import crud, schemas
-from app.database import get_db
+from app.api import deps
 
 router = APIRouter()
 
 @router.get("/metrics", response_model=schemas.DashboardMetrics)
-def get_dashboard_metrics(db: Session = Depends(get_db)):
+def get_dashboard_metrics(db: Session = Depends(deps.get_db)):
     """
     Get key metrics for the dashboard.
     """

--- a/backend/app/api/v1/endpoints/leads.py
+++ b/backend/app/api/v1/endpoints/leads.py
@@ -3,12 +3,16 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from app import crud, schemas
-from app.database import get_db
+from app.api import deps
 
 router = APIRouter()
 
 @router.get("/", response_model=List[schemas.LeadOut])
-def read_leads(db: Session = Depends(get_db), skip: int = 0, limit: int = 100):
+def read_leads(
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+):
     """
     Retrieve all leads.
     """

--- a/backend/app/api/v1/endpoints/quiz.py
+++ b/backend/app/api/v1/endpoints/quiz.py
@@ -3,12 +3,12 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from app import crud, schemas
-from app.database import get_db
+from app.api import deps
 
 router = APIRouter()
 
 @router.get("/quizzes/{quiz_id}", response_model=schemas.Quiz)
-def read_quiz(quiz_id: int, db: Session = Depends(get_db)):
+def read_quiz(quiz_id: int, db: Session = Depends(deps.get_db)):
     """
     Получить структуру квиза по его ID.
     Это то, что фронтенд будет запрашивать для отображения опросника.
@@ -19,7 +19,7 @@ def read_quiz(quiz_id: int, db: Session = Depends(get_db)):
     return db_quiz
 
 @router.post("/leads", response_model=schemas.Lead)
-def submit_lead(lead: schemas.LeadCreate, db: Session = Depends(get_db)):
+def submit_lead(lead: schemas.LeadCreate, db: Session = Depends(deps.get_db)):
     """
     Принять ответы квиза, рассчитать стоимость и сохранить лид.
     Возвращает созданный лид с итоговой ценой.

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,11 +1,13 @@
 from sqlalchemy.orm import Session
+
 from app import crud, schemas
+from app.db.base import Base
+from app.db.session import engine
 
 def init_db(db: Session) -> None:
-    """
-    Инициализация базы данных.
-    Проверяет наличие квиза и, если его нет, создает его.
-    """
+    """Create tables and seed initial quiz data if missing."""
+    # Ensure all tables exist. Alembic should be used in production.
+    Base.metadata.create_all(bind=engine)
     quiz = crud.quiz.get(db, id=1)
     if quiz:
         print("Quiz data already exists. Skipping seeding.")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,22 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import quiz
-from app.database import Base, engine
 
-# Создаем таблицы в БД (для первого запуска)
-# В продакшене лучше использовать Alembic
-Base.metadata.create_all(bind=engine)
+from app.api.v1.endpoints import quiz
+from app.db.init_db import init_db
+from app.db.session import SessionLocal
 
 app = FastAPI(
     title="LeadConverter Pro API",
     description="API для интерактивного квиз-калькулятора.",
-    version="1.0.0"
+    version="1.0.0",
 )
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize the database on application startup."""
+    # Use a context manager so the session always closes
+    with SessionLocal() as db:
+        init_db(db)
 
 # Подключаем роутеры
 app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz & Leads"])


### PR DESCRIPTION
## Summary
- initialize database tables and seed data during startup
- manage DB sessions via context managers
- use shared dependency for DB sessions in endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884dfed92548331807b9075189a6f5f