### PR TITLE
feat: add dashboard metrics

### DIFF
--- a/backend/api/v1/endpoints/dashboard.py
+++ b/backend/api/v1/endpoints/dashboard.py
@@ -1,15 +1,14 @@
 # backend/app/api/v1/endpoints/dashboard.py
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from app import crud, schemas
+
+from app.crud.dashboard import get_dashboard_metrics
+from app.schemas.dashboard import DashboardMetrics
 from app.database import get_db
 
 router = APIRouter()
 
-@router.get("/metrics", response_model=schemas.DashboardMetrics)
-def get_dashboard_metrics(db: Session = Depends(get_db)):
-    """
-    Get key metrics for the dashboard.
-    """
-    metrics = crud.get_dashboard_metrics(db)
-    return metrics
+@router.get("/metrics", response_model=DashboardMetrics)
+def read_dashboard_metrics(db: Session = Depends(get_db)):
+    """Get key metrics for the dashboard."""
+    return get_dashboard_metrics(db)

--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -1,2 +1,3 @@
 from .crud_quiz import quiz
 from .crud_lead import lead
+from .dashboard import get_dashboard_metrics

--- a/backend/crud/dashboard.py
+++ b/backend/crud/dashboard.py
@@ -1,0 +1,12 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.lead import Lead
+from app.schemas.dashboard import DashboardMetrics
+
+
+def get_dashboard_metrics(db: Session) -> DashboardMetrics:
+    """Calculate basic statistics for the dashboard."""
+    total_leads = db.query(func.count(Lead.id)).scalar() or 0
+    average_check = db.query(func.avg(Lead.final_price)).scalar() or 0.0
+    return DashboardMetrics(total_leads=total_leads, average_check=average_check)

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,2 +1,3 @@
 from .quiz import Quiz, QuizCreate, Question, QuestionCreate, Option, OptionCreate
 from .lead import Lead, LeadCreate
+from .dashboard import DashboardMetrics

--- a/backend/schemas/dashboard.py
+++ b/backend/schemas/dashboard.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, Field
+
+
+class DashboardMetrics(BaseModel):
+    """Schema representing metrics displayed on the admin dashboard."""
+    total_leads: int = Field(..., description="Общее количество лидов")
+    average_check: float = Field(..., description="Средний чек по лидам")


### PR DESCRIPTION
## Summary
- add DashboardMetrics schema
- compute dashboard metrics in new crud function
- expose metrics endpoint with new schema and function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68909ebf893c8331bf3fc23eca6b989b