### PR TITLE
Refactor API routing to use central router

### DIFF
--- a/backend/api/v1/api.py
+++ b/backend/api/v1/api.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from app.api.v1.endpoints import quizzes, leads, dashboard
+
+api_router = APIRouter()
+api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
+api_router.include_router(leads.router, prefix="/leads", tags=["leads"])
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
+

--- a/backend/api/v1/endpoints/api.py
+++ b/backend/api/v1/endpoints/api.py
@@ -1,8 +1,0 @@
-# backend/app/api/v1/api.py
-from fastapi import APIRouter
-from app.api.v1.endpoints import quizzes, leads, dashboard # Добавили leads и dashboard
-
-api_router = APIRouter()
-api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
-api_router.include_router(leads.router, prefix="/leads", tags=["leads"]) # Новая строка
-api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"]) # Новая строка

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import quiz
+from app.api.v1.api import api_router
 from app.database import Base, engine
 
 # Создаем таблицы в БД (для первого запуска)
@@ -13,8 +13,9 @@ app = FastAPI(
 )
 
 # Подключаем роутеры
-app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz & Leads"])
+app.include_router(api_router, prefix="/api/v1")
 
 @app.get("/")
 def read_root():
     return {"message": "Welcome to LeadConverter Pro API"}
+


### PR DESCRIPTION
## Summary
- add `app.api.v1.api` module aggregating quizzes, leads, and dashboard routers
- update `backend/main.py` to include new `api_router`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68909ec0616083319a9416f9fcc4fe42