### PR TITLE
Update lead submission endpoint and payload

### DIFF
--- a/frontend/src/services/lead.service.js
+++ b/frontend/src/services/lead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 class LeadService {
   create(leadData) {
-    return apiClient.post('/api/v1/leads/', leadData);
+    return apiClient.post('/api/v1/leads/submit', leadData);
   }
 }
 

--- a/frontend/src/stores/quiz.store.js
+++ b/frontend/src/stores/quiz.store.js
@@ -31,23 +31,29 @@ export const useQuizStore = defineStore('quiz', {
       return basePricePerMeter * state.area;
     },
     leadPayload: (state) => {
-      const answers_data = {};
+      const answers = [];
       if (state.quizData) {
         state.quizData.questions.forEach(q => {
           if (q.question_type === 'slider') {
-            answers_data[q.text] = `${state.area} м²`;
+            answers.push({
+              question_id: q.id,
+              value: state.area,
+            });
           } else {
             const optionId = state.selectedOptions[q.id];
             if (optionId) {
-              const option = q.options.find(o => o.id === optionId);
-              answers_data[q.text] = option ? option.text : 'Не выбрано';
+              answers.push({
+                question_id: q.id,
+                option_id: optionId,
+              });
             }
           }
         });
       }
       return {
-        final_price: state.totalPrice,
-        answers_data,
+        quiz_id: state.quizData ? state.quizData.id : null,
+        client_email: '',
+        answers,
       };
     },
   },
@@ -84,7 +90,7 @@ export const useQuizStore = defineStore('quiz', {
       this.isSubmittingLead = true;
       this.leadSubmissionError = null;
       try {
-        const payload = { ...this.leadPayload, email };
+        const payload = { ...this.leadPayload, client_email: email };
         await leadService.create(payload);
         this.closeLeadModal();
         this.isLeadSubmittedSuccessfully = true;


### PR DESCRIPTION
## Summary
- point lead service to new `/api/v1/leads/submit` endpoint
- send `quiz_id`, `client_email`, and structured answers when submitting a lead

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68909ec0ea548331abd1c076e51d1125