### PR TITLE
fix: update admin dashboard link

### DIFF
--- a/frontend/src/layouts/AdminLayout.vue
+++ b/frontend/src/layouts/AdminLayout.vue
@@ -4,7 +4,7 @@
     <aside class="sidebar">
       <h2 class="sidebar-title">LeadConverter</h2>
       <nav>
-        <router-link to="/admin/dashboard" class="nav-link">Дашборд</router-link>
+        <router-link to="/admin" class="nav-link">Дашборд</router-link>
         <router-link to="/admin/leads" class="nav-link">Лиды</router-link>
       </nav>
       <button @click="logout" class="logout-button">Выйти</button>
@@ -52,7 +52,7 @@ const logout = () => {
   margin-bottom: 10px;
   transition: background-color 0.3s, color 0.3s;
 }
-.nav-link:hover, .router-link-active {
+.nav-link:hover, .router-link-exact-active {
   background-color: #34495e;
   color: white;
 }


### PR DESCRIPTION
## Summary
- point admin dashboard link to `/admin`
- ensure nav highlights only the active admin route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68909ec2191c833198ff77073f618dae