### PR TITLE
Fix PDF generator encoding and add PDF generation test

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,2 +1,2 @@
 from .quiz import Quiz, QuizCreate, Question, QuestionCreate, Option, OptionCreate
-from .lead import Lead, LeadCreate
+from .lead import LeadAnswerIn, LeadCreateIn, LeadCreateInternal, LeadOut

--- a/backend/services/pdf_generator.py
+++ b/backend/services/pdf_generator.py
@@ -16,7 +16,7 @@ def generate_lead_pdf(lead_data: LeadOut) -> str:
     <!DOCTYPE html>
     <html lang="ru">
     <head>
-        <meta charset="UTF-axl">
+        <meta charset="UTF-8">
         <title>Смета по вашему проекту</title>
         <style>
             body {{ font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #333; }}

--- a/backend/tests/test_pdf_generator.py
+++ b/backend/tests/test_pdf_generator.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import shutil
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import backend as app  # type: ignore
+sys.modules['app'] = app
+from app.services import pdf_generator
+from app.schemas.lead import LeadOut
+
+
+def test_generate_pdf_creates_file(tmp_path):
+    # Remove default directory created at import to avoid repository pollution
+    if os.path.exists(pdf_generator.PDF_STORAGE_PATH):
+        shutil.rmtree(pdf_generator.PDF_STORAGE_PATH)
+
+    pdf_generator.PDF_STORAGE_PATH = str(tmp_path)
+    os.makedirs(pdf_generator.PDF_STORAGE_PATH, exist_ok=True)
+
+    lead = LeadOut(
+        id=1,
+        client_email="test@example.com",
+        final_price=100.0,
+        answers_details={"Question": "Answer"},
+    )
+
+    pdf_path = pdf_generator.generate_lead_pdf(lead)
+
+    assert pdf_path.endswith(".pdf")
+    assert os.path.exists(pdf_path)
+    assert os.path.getsize(pdf_path) > 0


### PR DESCRIPTION
## Summary
- use UTF-8 in the PDF generator HTML template
- export lead schemas and add unit test to ensure PDFs are generated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68909ec3e5388331bee6e7f2443b641e