### PR TITLE
refactor: unify question type naming

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -13,7 +13,7 @@ class Question(Base):
     __tablename__ = "questions"
     id = Column(Integer, primary_key=True, index=True)
     text = Column(String)
-    question_type = Column(String, default="radio") # radio, checkbox, slider
+    question_type = Column(String, default="single-choice")  # single-choice, slider
     quiz_id = Column(Integer, ForeignKey("quizzes.id"))
     quiz = relationship("Quiz", back_populates="questions")
     options = relationship("Option", back_populates="question")
@@ -31,4 +31,5 @@ class Lead(Base):
     id = Column(Integer, primary_key=True, index=True)
     client_email = Column(String, index=True)
     estimated_cost = Column(Float)
-    details = Column(JSON) # Здесь будем хранить все ответы квиза
+    details = Column(JSON)  # Здесь будем хранить все ответы квиза
+

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,2 +1,25 @@
-from .quiz import Quiz, QuizCreate, Question, QuestionCreate, Option, OptionCreate
+"""Public exports for schema objects."""
+
+from .quiz import (
+    Option,
+    OptionCreate,
+    Question,
+    QuestionCreate,
+    QuestionType,
+    Quiz,
+    QuizCreate,
+)
 from .lead import Lead, LeadCreate
+
+__all__ = [
+    "Option",
+    "OptionCreate",
+    "Question",
+    "QuestionCreate",
+    "QuestionType",
+    "Quiz",
+    "QuizCreate",
+    "Lead",
+    "LeadCreate",
+]
+

--- a/backend/schemas/quiz.py
+++ b/backend/schemas/quiz.py
@@ -1,5 +1,13 @@
-from pydantic import BaseModel, Field
+from enum import Enum
 from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+# --- Допустимые типы вопросов ---
+class QuestionType(str, Enum):
+    """Enumeration of supported quiz question types."""
+    SINGLE_CHOICE = "single-choice"  # user selects one option
+    SLIDER = "slider"  # numeric slider input
 
 # --- Схемы для Вариантов Ответов (Option) ---
 class OptionBase(BaseModel):
@@ -20,7 +28,7 @@ class Option(OptionBase):
 class QuestionBase(BaseModel):
     text: str
     description: Optional[str] = None
-    question_type: str
+    question_type: QuestionType
     order: int
 
 class QuestionCreate(QuestionBase):
@@ -32,6 +40,7 @@ class Question(QuestionBase):
 
     class Config:
         from_attributes = True
+
 
 # --- Схемы для Квиза (Quiz) ---
 class QuizBase(BaseModel):
@@ -48,3 +57,4 @@ class Quiz(QuizBase):
 
     class Config:
         from_attributes = True
+

--- a/backend/schemas/schemas.py
+++ b/backend/schemas/schemas.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, EmailStr
-from typing import List, Optional, Dict, Any
+from typing import Dict, List, Optional, Any
+
+from .quiz import QuestionType
 
 # --- Схемы для отображения квиза ---
 
@@ -10,10 +12,11 @@ class Option(BaseModel):
     class Config:
         orm_mode = True
 
+
 class Question(BaseModel):
     id: int
     text: str
-    question_type: str
+    question_type: QuestionType
     options: List[Option]
 
     class Config:
@@ -47,3 +50,4 @@ class Lead(BaseModel):
 
     class Config:
         orm_mode = True
+


### PR DESCRIPTION
## Summary
- replace legacy `radio` question type with `single-choice`
- document allowed question types via `QuestionType` enum and update schemas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68909ec5236c8331b7ea4f04b6cd88f0