### PR TITLE
Fix PDF charset encoding to UTF-8

### DIFF
--- a/backend/services/pdf_generator.py
+++ b/backend/services/pdf_generator.py
@@ -16,7 +16,7 @@ def generate_lead_pdf(lead_data: LeadOut) -> str:
     <!DOCTYPE html>
     <html lang="ru">
     <head>
-        <meta charset="UTF-axl">
+        <meta charset="UTF-8">
         <title>Смета по вашему проекту</title>
         <style>
             body {{ font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #333; }}


### PR DESCRIPTION
## Summary
- ensure generated PDF uses UTF-8 encoding for proper non-ASCII support

## Testing
- `pytest`
- `pdftotext generated_pdfs/lead_1_estimate.pdf - | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68909f27ed8483319e9a3859c878fd58