### PR TITLE
Fix Base import in lead model

### DIFF
--- a/backend/models/lead.py
+++ b/backend/models/lead.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, Float, JSON, DateTime, func
-from .database import Base
+from app.db.base import Base
 
 class Lead(Base):
     __tablename__ = "leads"
@@ -11,5 +11,5 @@ class Lead(Base):
     
     # Используем JSON для гибкого хранения расшифровки ответов
     answers_details = Column(JSON, nullable=False)
-    
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
## Summary
- fix lead model to import shared Base from central db module

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest`
- `PYTHONPATH=backend uvicorn app.main:app --host 127.0.0.1 --port 8000 --log-level warning` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68909f24de188331acf7e482ae2aa440