### PR TITLE
Fix Alembic env imports

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -5,7 +5,8 @@ from alembic import context
 # Теперь, когда entrypoint.sh устанавливает PYTHONPATH,
 # эти импорты будут работать без каких-либо манипуляций с sys.path
 from db.base import Base
-from db.models import quiz, lead, settings
+from app.models import quiz, lead
+from app.core.config import settings
 
 config = context.config
 


### PR DESCRIPTION
## Summary
- fix Alembic script to import quiz, lead, and settings from new app modules

## Testing
- `alembic revision --autogenerate` *(fails: No 'script_location' key found in configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68909f2a665083318ec04447bb710362