### PR TITLE
fix(frontend): correct lead endpoints

### DIFF
--- a/frontend/src/services/adminLead.service.js
+++ b/frontend/src/services/adminLead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js'
 
 class AdminLeadService {
   getLeads() {
-    return apiClient.get('/api/v1/leads/')
+    return apiClient.get('/api/v1/leads')
   }
 }
 

--- a/frontend/src/services/lead.service.js
+++ b/frontend/src/services/lead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 class LeadService {
   create(leadData) {
-    return apiClient.post('/api/v1/leads/', leadData);
+    return apiClient.post('/api/v1/leads/submit', leadData);
   }
 }
 


### PR DESCRIPTION
## Summary
- update lead creation service to use `/api/v1/leads/submit`
- adjust admin leads service to match new backend path

## Testing
- `npm run lint`
- Attempted service call with Node (fails: Cannot read properties of undefined (reading 'VITE_API_BASE_URL'))

------
https://chatgpt.com/codex/tasks/task_b_68909f3028f483319cd12451eec0ee7b