### PR TITLE
chore: unify leads endpoint path

### DIFF
--- a/backend/api/v1/endpoints/api.py
+++ b/backend/api/v1/endpoints/api.py
@@ -1,8 +1,8 @@
 # backend/app/api/v1/api.py
 from fastapi import APIRouter
-from app.api.v1.endpoints import quizzes, leads, dashboard # Добавили leads и dashboard
+from app.api.v1.endpoints import quizzes, leads, dashboard
 
 api_router = APIRouter()
 api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
-api_router.include_router(leads.router, prefix="/leads", tags=["leads"]) # Новая строка
-api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"]) # Новая строка
+api_router.include_router(leads.router, prefix="/leads", tags=["leads"])
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])

--- a/backend/api/v1/endpoints/leads.py
+++ b/backend/api/v1/endpoints/leads.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from typing import List, Any
 
@@ -8,7 +8,8 @@ from app.services import pdf_generator # Импортируем наш новы�
 
 router = APIRouter()
 
-@router.post("/submit", response_model=schemas.lead.LeadOut)
+
+@router.post("", response_model=schemas.lead.LeadOut)
 def submit_lead(
     *,
     db: Session = Depends(deps.get_db),
@@ -35,7 +36,7 @@ def submit_lead(
     return lead_out_data
 
 
-@router.get("/", response_model=List[schemas.lead.LeadOut])
+@router.get("", response_model=List[schemas.lead.LeadOut])
 def read_leads(
     db: Session = Depends(deps.get_db),
     skip: int = 0,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import quiz
+from app.api.v1.endpoints.api import api_router
 from app.database import Base, engine
 
 # Создаем таблицы в БД (для первого запуска)
@@ -9,12 +9,13 @@ Base.metadata.create_all(bind=engine)
 app = FastAPI(
     title="LeadConverter Pro API",
     description="API для интерактивного квиз-калькулятора.",
-    version="1.0.0"
+    version="1.0.0",
 )
 
-# Подключаем роутеры
-app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz & Leads"])
+app.include_router(api_router, prefix="/api/v1")
+
 
 @app.get("/")
 def read_root():
     return {"message": "Welcome to LeadConverter Pro API"}
+

--- a/frontend/src/services/adminLead.service.js
+++ b/frontend/src/services/adminLead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js'
 
 class AdminLeadService {
   getLeads() {
-    return apiClient.get('/api/v1/leads/')
+    return apiClient.get('/api/v1/leads')
   }
 }
 

--- a/frontend/src/services/lead.service.js
+++ b/frontend/src/services/lead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 class LeadService {
   create(leadData) {
-    return apiClient.post('/api/v1/leads/', leadData);
+    return apiClient.post('/api/v1/leads', leadData);
   }
 }
 


### PR DESCRIPTION
## Summary
- expose lead submission and listing at `/api/v1/leads`
- wire API v1 router and clean imports
- align frontend services with new endpoint

## Testing
- `python -m py_compile backend/api/v1/endpoints/leads.py backend/api/v1/endpoints/api.py backend/main.py`
- `npm run lint`
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68909f2999ec8331986cb01d9ecfe167