### PR TITLE
refactor: use central API router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import quiz
+from app.api.v1.endpoints.api import api_router
 from app.database import Base, engine
 
 # Создаем таблицы в БД (для первого запуска)
@@ -13,7 +13,7 @@ app = FastAPI(
 )
 
 # Подключаем роутеры
-app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz & Leads"])
+app.include_router(api_router, prefix="/api/v1")
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- switch main app to import the aggregated API router
- mount the API router under `/api/v1`

## Testing
- `pytest`
- `SECRET_KEY=secret DATABASE_URL=sqlite:///./test.db python - <<'PY'
import app.main
PY` *(fails: ModuleNotFoundError: No module named 'app.models.database')*

------
https://chatgpt.com/codex/tasks/task_b_68909f2867c88331af23cdb87ec15a6b