### PR TITLE
Mount API router and add dashboard metrics stub

### DIFF
--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -1,2 +1,3 @@
 from .crud_quiz import quiz
 from .crud_lead import lead
+from .crud_dashboard import get_dashboard_metrics

--- a/backend/crud/crud_dashboard.py
+++ b/backend/crud/crud_dashboard.py
@@ -1,0 +1,9 @@
+from sqlalchemy.orm import Session
+
+
+def get_dashboard_metrics(db: Session) -> dict:
+    """Return basic metrics for the dashboard.
+
+    Currently returns static values as a placeholder.
+    """
+    return {"total_leads": 0, "average_check": 0.0}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import quiz
+from app.api.v1.endpoints.api import api_router
 from app.database import Base, engine
 
 # Создаем таблицы в БД (для первого запуска)
@@ -9,11 +9,11 @@ Base.metadata.create_all(bind=engine)
 app = FastAPI(
     title="LeadConverter Pro API",
     description="API для интерактивного квиз-калькулятора.",
-    version="1.0.0"
+    version="1.0.0",
 )
 
 # Подключаем роутеры
-app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz & Leads"])
+app.include_router(api_router, prefix="/api/v1")
 
 @app.get("/")
 def read_root():

--- a/backend/models/lead.py
+++ b/backend/models/lead.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, Float, JSON, DateTime, func
-from .database import Base
+from app.db.base import Base
 
 class Lead(Base):
     __tablename__ = "leads"

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,2 +1,3 @@
 from .quiz import Quiz, QuizCreate, Question, QuestionCreate, Option, OptionCreate
-from .lead import Lead, LeadCreate
+from .dashboard import DashboardMetrics
+from . import lead

--- a/backend/schemas/dashboard.py
+++ b/backend/schemas/dashboard.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class DashboardMetrics(BaseModel):
+    total_leads: int
+    average_check: float


### PR DESCRIPTION
## Summary
- mount the consolidated `api_router` in the FastAPI entrypoint
- add a minimal dashboard metrics schema and CRUD stub
- fix Lead model to use shared Base class

## Testing
- `pytest`
- `python - <<'PY'
from fastapi.testclient import TestClient
from app.main import app
client = TestClient(app)
print(client.get("/api/v1/dashboard/metrics").json())
PY`

------
https://chatgpt.com/codex/tasks/task_b_68909f30707483318c545378ea2abcd1