### PR TITLE
Add logging to API endpoints

### DIFF
--- a/backend/api/v1/endpoints/__init__.py
+++ b/backend/api/v1/endpoints/__init__.py
@@ -1,0 +1,7 @@
+import logging
+import os
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
+

--- a/backend/api/v1/endpoints/api.py
+++ b/backend/api/v1/endpoints/api.py
@@ -1,8 +1,18 @@
 # backend/app/api/v1/api.py
+import logging
+import os
+
 from fastapi import APIRouter
-from app.api.v1.endpoints import quizzes, leads, dashboard # Добавили leads и dashboard
+from app.api.v1.endpoints import quizzes, leads, dashboard  # Добавили leads и dashboard
+
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 api_router = APIRouter()
 api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
-api_router.include_router(leads.router, prefix="/leads", tags=["leads"]) # Новая строка
-api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"]) # Новая строка
+api_router.include_router(leads.router, prefix="/leads", tags=["leads"])  # Новая строка
+api_router.include_router(
+    dashboard.router, prefix="/dashboard", tags=["dashboard"]
+)  # Новая строка

--- a/backend/api/v1/endpoints/dashboard.py
+++ b/backend/api/v1/endpoints/dashboard.py
@@ -1,15 +1,26 @@
 # backend/app/api/v1/endpoints/dashboard.py
+import logging
+import os
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from app import crud, schemas
 from app.database import get_db
 
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 @router.get("/metrics", response_model=schemas.DashboardMetrics)
 def get_dashboard_metrics(db: Session = Depends(get_db)):
-    """
-    Get key metrics for the dashboard.
-    """
-    metrics = crud.get_dashboard_metrics(db)
+    """Get key metrics for the dashboard."""
+    logger.info("Fetching dashboard metrics")
+    try:
+        metrics = crud.get_dashboard_metrics(db)
+    except Exception:
+        logger.exception("Failed to fetch dashboard metrics")
+        raise
     return metrics

--- a/backend/api/v1/endpoints/health.py
+++ b/backend/api/v1/endpoints/health.py
@@ -1,10 +1,17 @@
+import logging
+import os
+
 from fastapi import APIRouter
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
 @router.get("/health", status_code=200)
 def check_health():
-    """
-    Простой эндпоинт для проверки работоспособности сервиса.
-    """
+    """Простой эндпоинт для проверки работоспособности сервиса."""
+    logger.debug("Health check requested")
     return {"status": "ok"}

--- a/backend/api/v1/endpoints/leads.py
+++ b/backend/api/v1/endpoints/leads.py
@@ -1,10 +1,18 @@
+import logging
+import os
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List, Any
 
 from app import crud, schemas
 from app.api import deps
-from app.services import pdf_generator # Импортируем наш новый сервис
+from app.services import pdf_generator  # Импортируем наш новый сервис
+
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -14,20 +22,27 @@ def submit_lead(
     db: Session = Depends(deps.get_db),
     lead_in: schemas.lead.LeadCreateIn,
 ) -> Any:
-    """
-    Принять ответы квиза, рассчитать стоимость, сохранить лид и сгенерировать PDF.
-    Это основной эндпоинт для фронтенда.
-    """
-    # 1. Создаем лид с расчетом цены через CRUD
-    created_lead = crud.lead.create_with_calculation(db=db, obj_in=lead_in)
+    """Принять ответы квиза, рассчитать стоимость, сохранить лид и сгенерировать PDF."""
+    logger.info("Submitting lead: %s", lead_in.model_dump())
+    try:
+        logger.debug("Creating lead with calculation")
+        created_lead = crud.lead.create_with_calculation(db=db, obj_in=lead_in)
+    except Exception:
+        logger.exception("Failed to create lead")
+        raise HTTPException(status_code=500, detail="Failed to create lead")
 
-    # 2. Преобразуем созданный объект в Pydantic-схему для ответа
+    logger.debug("Validating created lead data for response")
     lead_out_data = schemas.lead.LeadOut.model_validate(created_lead)
 
-    # 3. Генерируем PDF и получаем путь к нему
-    # В будущем здесь можно будет вернуть URL для скачивания
-    pdf_path = pdf_generator.generate_lead_pdf(lead_out_data)
-    lead_out_data.pdf_url = pdf_path # Добавляем путь в ответ API
+    try:
+        logger.debug("Generating PDF for lead %s", created_lead.id)
+        pdf_path = pdf_generator.generate_lead_pdf(lead_out_data)
+    except Exception:
+        logger.exception("Failed to generate PDF for lead %s", created_lead.id)
+        raise HTTPException(status_code=500, detail="Failed to generate PDF")
+
+    lead_out_data.pdf_url = pdf_path  # Добавляем путь в ответ API
+    logger.info("Lead %s processed successfully", lead_out_data.id)
 
     # 4. Здесь же можно будет добавить отправку уведомлений в Telegram/Email
     # notification_service.send_new_lead_notification(lead_out_data)
@@ -41,8 +56,7 @@ def read_leads(
     skip: int = 0,
     limit: int = 100,
 ) -> Any:
-    """
-    Получить список всех лидов для админ-панели.
-    """
+    """Получить список всех лидов для админ-панели."""
+    logger.debug("Fetching leads: skip=%s limit=%s", skip, limit)
     leads = crud.lead.get_multi(db, skip=skip, limit=limit)
     return leads

--- a/backend/api/v1/endpoints/quiz.py
+++ b/backend/api/v1/endpoints/quiz.py
@@ -1,9 +1,17 @@
+import logging
+import os
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
 
 from app import crud, schemas
 from app.database import get_db
+
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -13,16 +21,23 @@ def read_quiz(quiz_id: int, db: Session = Depends(get_db)):
     Получить структуру квиза по его ID.
     Это то, что фронтенд будет запрашивать для отображения опросника.
     """
+    logger.info("Fetching quiz %s", quiz_id)
     db_quiz = crud.get_quiz(db, quiz_id=quiz_id)
     if db_quiz is None:
+        logger.warning("Quiz %s not found", quiz_id)
         raise HTTPException(status_code=404, detail="Quiz not found")
+    logger.info("Quiz %s retrieved successfully", quiz_id)
     return db_quiz
 
 @router.post("/leads", response_model=schemas.Lead)
 def submit_lead(lead: schemas.LeadCreate, db: Session = Depends(get_db)):
-    """
-    Принять ответы квиза, рассчитать стоимость и сохранить лид.
-    Возвращает созданный лид с итоговой ценой.
-    """
-    # Здесь можно добавить логику для отправки PDF и уведомлений в будущем
-    return crud.create_lead(db=db, lead_data=lead)
+    """Принять ответы квиза, рассчитать стоимость и сохранить лид."""
+    logger.info("Submitting lead: %s", lead.model_dump())
+    try:
+        created_lead = crud.create_lead(db=db, lead_data=lead)
+    except Exception:
+        logger.exception("Failed to create lead")
+        raise HTTPException(status_code=500, detail="Failed to create lead")
+    logger.info("Lead %s created successfully", created_lead.id)
+    return created_lead
+

--- a/backend/api/v1/endpoints/quizzes.py
+++ b/backend/api/v1/endpoints/quizzes.py
@@ -1,12 +1,14 @@
 import logging
+import os
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import Any
 from app import crud, schemas
 from app.api import deps
 
-# Настраиваем базовый логгер
-logging.basicConfig(level=logging.INFO)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -19,7 +21,8 @@ def read_quiz(
     """
     Получить полную структуру квиза по его ID.
     """
-    logger.info(f"API: Request received for quiz_id: {quiz_id}")
+    logger.info("API: Request received for quiz_id: %s", quiz_id)
+    logger.debug("API: Fetching quiz from database")
     quiz = crud.quiz.get(db=db, id=quiz_id)
     
     if not quiz:
@@ -29,5 +32,9 @@ def read_quiz(
             detail="Quiz not found",
         )
     
-    logger.info(f"API: Returning quiz '{quiz.title}' with {len(quiz.questions)} questions.")
+    logger.info(
+        "API: Returning quiz '%s' with %s questions.",
+        quiz.title,
+        len(quiz.questions),
+    )
     return quiz


### PR DESCRIPTION
## Summary
- add module-level loggers configured via `LOG_LEVEL`
- log steps and errors in lead submission
- trace health check calls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890a12d97f88331895174d006361b9c