### PR TITLE
feat: add configurable logger

### DIFF
--- a/frontend/src/components/quiz/LeadFormModal.vue
+++ b/frontend/src/components/quiz/LeadFormModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue';
 import { useQuizStore } from '../../stores/quiz.store.js';
+import logger from '../../utils/logger.js';
 
 const quizStore = useQuizStore();
 const email = ref('');
@@ -9,13 +10,14 @@ function closeModal() {
   quizStore.closeLeadModal();
 }
 
-async function handleSubmit() {
-  if (!email.value) {
-    quizStore.leadSubmissionError = "Email не может быть пустым.";
-    return;
+  async function handleSubmit() {
+    if (!email.value) {
+      quizStore.leadSubmissionError = "Email не может быть пустым.";
+      return;
+    }
+    logger.log('Submitting lead form', { email: email.value });
+    await quizStore.submitLead(email.value);
   }
-  await quizStore.submitLead(email.value);
-}
 </script>
 
 <template>

--- a/frontend/src/stores/quiz.store.js
+++ b/frontend/src/stores/quiz.store.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import quizService from '../services/quiz.service.js';
 import leadService from '../services/lead.service.js';
+import logger from '../utils/logger.js';
 
 const getInitialState = () => ({
   quizData: null,
@@ -60,7 +61,7 @@ export const useQuizStore = defineStore('quiz', {
         this.quizData = response.data;
       } catch (err) {
         this.error = 'Не удалось загрузить квиз.';
-        console.error(err);
+        logger.error(err);
       } finally {
         this.isLoading = false;
       }
@@ -89,7 +90,7 @@ export const useQuizStore = defineStore('quiz', {
         this.closeLeadModal();
         this.isLeadSubmittedSuccessfully = true;
       } catch (error) {
-        console.error("Lead submission failed:", error);
+        logger.error('Lead submission failed:', error);
         this.leadSubmissionError = "Произошла ошибка. Пожалуйста, проверьте email и попробуйте снова.";
       } finally {
         this.isSubmittingLead = false;

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -1,0 +1,21 @@
+const levels = { log: 0, warn: 1, error: 2, silent: 3 };
+
+const envLevel = import.meta.env.VITE_LOG_LEVEL || (import.meta.env.PROD ? 'silent' : 'log');
+const currentLevel = levels[envLevel] ?? levels.log;
+
+function createLogger(level, method) {
+  return (message, details) => {
+    if (level < currentLevel) return;
+    if (details !== undefined) {
+      method(message, details);
+    } else {
+      method(message);
+    }
+  };
+}
+
+export const log = createLogger(levels.log, console.log);
+export const warn = createLogger(levels.warn, console.warn);
+export const error = createLogger(levels.error, console.error);
+
+export default { log, warn, error };


### PR DESCRIPTION
## Summary
- introduce logger utility with level control and production suppression
- use logger in quiz store and lead form modal instead of console

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6890a12dfa848331978d41decbaf03b0