### PR TITLE
Add log summarization endpoint using OpenAI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,13 @@
-from fastapi import FastAPI
+import os
+
+import openai
+from dotenv import load_dotenv
+from fastapi import FastAPI, File, HTTPException, UploadFile
+
 from app.api.v1.endpoints.api import api_router
 from app.database import Base, engine
+
+load_dotenv()
 
 # Создаем таблицы в БД (для первого запуска)
 # В продакшене лучше использовать Alembic
@@ -18,3 +25,38 @@ app.include_router(api_router, prefix="/api/v1")
 @app.get("/")
 def read_root():
     return {"message": "Welcome to LeadConverter Pro API"}
+
+
+@app.post("/summarize-log")
+async def summarize_log(file: UploadFile = File(...)):
+    try:
+        content_bytes = await file.read()
+        log_text = content_bytes.decode("utf-8")
+    except Exception as exc:  # pragma: no cover - simple validation
+        raise HTTPException(status_code=400, detail="Unable to read uploaded file") from exc
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OpenAI API key not configured")
+
+    openai.api_key = api_key
+    prompt = (
+        "Summarize the following application log entries in a concise manner:\n" + log_text
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant that summarizes logs.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+        )
+    except Exception as exc:  # pragma: no cover - API errors
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    summary = response.choices[0].message["content"].strip()
+    return {"summary": summary}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 python-dotenv==1.0.1
+openai==0.28.1
 pydantic==2.7.1
 pydantic-settings==2.2.1
 


### PR DESCRIPTION
## Summary
- add `/summarize-log` route for uploading JSON log files and returning an OpenAI-generated summary
- load environment variables via `python-dotenv` and use `OPENAI_API_KEY`
- include OpenAI SDK in backend requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895d9a6083c8331a804dd4a2b6e399a