### PR TITLE
Remove leftover nested submodule directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 .DS_Store
 Thumbs.db
 backend_log.txt
+
+# Legacy directory
+leadconverter-pro/


### PR DESCRIPTION
## Summary
- Remove obsolete `leadconverter-pro` submodule directory
- Ignore legacy `leadconverter-pro` directory in .gitignore

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6895dd65dd20833187fd926702307681