### PR TITLE
Add tenant isolation with row-level security

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ orchestrated through Docker Compose.
 - Vue 3 frontend powered by Vite
 - Dockerized development environment
 - Log summarization script with optional OpenAI integration
+- Basic multi-tenant isolation using PostgreSQL row-level security
 
 ## Installation
 ### Clone the repository
@@ -42,6 +43,10 @@ docker-compose up
 ```
 The backend will be available at <http://localhost:8000> and the frontend at
 <http://localhost:5173>.
+
+### Multi-tenant requests
+Each API request must include an `X-Tenant-ID` header identifying the tenant.
+Row-level security policies use this value to isolate data per tenant.
 
 ### Running without Docker
 Backend:

--- a/backend/api/v1/endpoints/leads.py
+++ b/backend/api/v1/endpoints/leads.py
@@ -4,7 +4,7 @@ from typing import List, Any
 
 from app import crud, schemas
 from app.api import deps
-from app.services import pdf_generator # Импортируем наш новый сервис
+from app.services import pdf_generator  # Импортируем наш новый сервис
 
 router = APIRouter()
 
@@ -12,6 +12,7 @@ router = APIRouter()
 def submit_lead(
     *,
     db: Session = Depends(deps.get_db),
+    tenant_id: str = Depends(deps.get_tenant_id),
     lead_in: schemas.lead.LeadCreateIn,
 ) -> Any:
     """
@@ -19,7 +20,9 @@ def submit_lead(
     Это основной эндпоинт для фронтенда.
     """
     # 1. Создаем лид с расчетом цены через CRUD
-    created_lead = crud.lead.create_with_calculation(db=db, obj_in=lead_in)
+    created_lead = crud.lead.create_with_calculation(
+        db=db, obj_in=lead_in, tenant_id=tenant_id
+    )
 
     # 2. Преобразуем созданный объект в Pydantic-схему для ответа
     lead_out_data = schemas.lead.LeadOut.model_validate(created_lead)
@@ -38,11 +41,12 @@ def submit_lead(
 @router.get("/", response_model=List[schemas.lead.LeadOut])
 def read_leads(
     db: Session = Depends(deps.get_db),
+    tenant_id: str = Depends(deps.get_tenant_id),
     skip: int = 0,
     limit: int = 100,
 ) -> Any:
     """
     Получить список всех лидов для админ-панели.
     """
-    leads = crud.lead.get_multi(db, skip=skip, limit=limit)
+    leads = crud.lead.get_multi(db, tenant_id=tenant_id, skip=skip, limit=limit)
     return leads

--- a/backend/api/v1/endpoints/quizzes.py
+++ b/backend/api/v1/endpoints/quizzes.py
@@ -15,12 +15,13 @@ router = APIRouter()
 def read_quiz(
     quiz_id: int,
     db: Session = Depends(deps.get_db),
+    tenant_id: str = Depends(deps.get_tenant_id),
 ) -> Any:
     """
     Получить полную структуру квиза по его ID.
     """
     logger.info(f"API: Request received for quiz_id: {quiz_id}")
-    quiz = crud.quiz.get(db=db, id=quiz_id)
+    quiz = crud.quiz.get(db=db, id=quiz_id, tenant_id=tenant_id)
     
     if not quiz:
         logger.warning(f"API: Quiz with id {quiz_id} not found in DB.")

--- a/backend/crud/crud_lead.py
+++ b/backend/crud/crud_lead.py
@@ -4,7 +4,9 @@ from app.models import quiz as quiz_model
 from app.schemas import lead as lead_schema
 
 class CRUDLead:
-    def create_with_calculation(self, db: Session, *, obj_in: lead_schema.LeadCreateIn) -> lead_model.Lead:
+    def create_with_calculation(
+        self, db: Session, *, obj_in: lead_schema.LeadCreateIn, tenant_id: str
+    ) -> lead_model.Lead:
         """
         Создает лид, производя расчеты на основе ответов.
         Это - сердце бизнес-логики.
@@ -45,7 +47,8 @@ class CRUDLead:
             quiz_id=obj_in.quiz_id,
             client_email=obj_in.client_email,
             final_price=final_price,
-            answers_details=answers_details
+            answers_details=answers_details,
+            tenant_id=tenant_id,
         )
 
         db_obj = lead_model.Lead(**lead_create_data.model_dump())
@@ -54,8 +57,16 @@ class CRUDLead:
         db.refresh(db_obj)
         return db_obj
 
-    def get_multi(self, db: Session, *, skip: int = 0, limit: int = 100) -> list[lead_model.Lead]:
-        return db.query(lead_model.Lead).offset(skip).limit(limit).all()
+    def get_multi(
+        self, db: Session, *, tenant_id: str, skip: int = 0, limit: int = 100
+    ) -> list[lead_model.Lead]:
+        return (
+            db.query(lead_model.Lead)
+            .filter(lead_model.Lead.tenant_id == tenant_id)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
 
 
 lead = CRUDLead()

--- a/backend/models/lead.py
+++ b/backend/models/lead.py
@@ -5,6 +5,7 @@ class Lead(Base):
     __tablename__ = "leads"
 
     id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(String, index=True, nullable=False)
     quiz_id = Column(Integer, nullable=False)
     client_email = Column(String, index=True, nullable=False)
     final_price = Column(Float, nullable=False)

--- a/backend/models/quiz.py
+++ b/backend/models/quiz.py
@@ -6,6 +6,7 @@ from app.database import Base
 class Quiz(Base):
     __tablename__ = "quizzes"
     id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(String, index=True, nullable=False)
     title = Column(String, index=True, nullable=False)
     description = Column(Text, nullable=True)
     questions = relationship("Question", back_populates="quiz", cascade="all, delete-orphan")

--- a/backend/schemas/lead.py
+++ b/backend/schemas/lead.py
@@ -19,6 +19,7 @@ class LeadCreateInternal(BaseModel):
     client_email: EmailStr
     final_price: float
     answers_details: Dict[str, Any]
+    tenant_id: str
 
 # Финальная схема для ответа API (то, что мы возвращаем фронтенду)
 class LeadOut(BaseModel):
@@ -27,6 +28,7 @@ class LeadOut(BaseModel):
     final_price: float = Field(..., description="Итоговая рассчитанная стоимость")
     answers_details: Dict[str, Any] = Field(..., description="Детализация ответов")
     pdf_url: Optional[str] = Field(None, description="Ссылка на сгенерированный PDF")
+    tenant_id: str
 
     class Config:
         from_attributes = True

--- a/backend/schemas/quiz.py
+++ b/backend/schemas/quiz.py
@@ -45,6 +45,7 @@ class QuizCreate(QuizBase):
 class Quiz(QuizBase):
     id: int
     questions: List[Question] = Field(default_factory=list)
+    tenant_id: str
 
     class Config:
         from_attributes = True

--- a/scripts/setup_rls.py
+++ b/scripts/setup_rls.py
@@ -1,0 +1,27 @@
+"""Enable basic row-level security for multi-tenant isolation."""
+
+from sqlalchemy import text
+from app.database import engine
+
+
+def main() -> None:
+    """Create RLS policies for tenant isolation on core tables."""
+    with engine.begin() as conn:
+        conn.execute(text("ALTER TABLE leads ENABLE ROW LEVEL SECURITY"))
+        conn.execute(text("ALTER TABLE leads FORCE ROW LEVEL SECURITY"))
+        conn.execute(
+            text(
+                "CREATE POLICY IF NOT EXISTS tenant_isolation_leads ON leads USING (tenant_id = current_setting('app.tenant_id')::text)"
+            )
+        )
+        conn.execute(text("ALTER TABLE quizzes ENABLE ROW LEVEL SECURITY"))
+        conn.execute(text("ALTER TABLE quizzes FORCE ROW LEVEL SECURITY"))
+        conn.execute(
+            text(
+                "CREATE POLICY IF NOT EXISTS tenant_isolation_quizzes ON quizzes USING (tenant_id = current_setting('app.tenant_id')::text)"
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add X-Tenant-ID dependency and set database session context
- extend lead and quiz models with tenant_id and filter queries
- include setup script for enabling PostgreSQL row-level security

## Testing
- `python -m py_compile backend/api/deps.py backend/api/v1/endpoints/leads.py backend/api/v1/endpoints/quizzes.py backend/crud/crud_lead.py backend/crud/crud_quiz.py backend/models/lead.py backend/models/quiz.py backend/schemas/lead.py backend/schemas/quiz.py scripts/setup_rls.py`


------
https://chatgpt.com/codex/tasks/task_b_6895dfaaa8408331ae3ff2b4c472316f