### PR TITLE
Add AI insights and vector index utilities

### DIFF
--- a/backend/api/v1/endpoints/ai.py
+++ b/backend/api/v1/endpoints/ai.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from pydantic import BaseModel, EmailStr
+
+from app.services import ai
+
+router = APIRouter()
+
+
+class LeadAIIn(BaseModel):
+    client_email: EmailStr | None = None
+    final_price: float = 0
+    answers_details: Dict[str, Any] = {}
+
+
+@router.post("/segment")
+def segment(lead: LeadAIIn) -> Dict[str, str]:
+    return {"segment": ai.auto_segment_lead(lead.model_dump())}
+
+
+@router.post("/questions")
+def questions(lead: LeadAIIn) -> Dict[str, Any]:
+    return {"questions": ai.generate_followup_questions(lead.model_dump())}
+
+
+@router.post("/ltv")
+def ltv(lead: LeadAIIn) -> Dict[str, float]:
+    return {"ltv": ai.predict_ltv(lead.model_dump())}
+
+
+@router.post("/insights")
+def insights(lead: LeadAIIn) -> Dict[str, Any]:
+    data = lead.model_dump()
+    return {
+        "segment": ai.auto_segment_lead(data),
+        "next_questions": ai.generate_followup_questions(data),
+        "ltv_prediction": ai.predict_ltv(data),
+    }

--- a/backend/api/v1/endpoints/api.py
+++ b/backend/api/v1/endpoints/api.py
@@ -1,8 +1,10 @@
-# backend/app/api/v1/endpoints/api.py  (добавление роутера)
-from app.api.v1.endpoints import quizzes, leads, dashboard, estimate
+from fastapi import APIRouter
+
+from app.api.v1.endpoints import quizzes, leads, dashboard, estimate, ai
 
 api_router = APIRouter()
 api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
 api_router.include_router(leads.router, prefix="/leads", tags=["leads"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(estimate.router, prefix="/estimate", tags=["estimate"])
+api_router.include_router(ai.router, prefix="/ai", tags=["ai"])

--- a/backend/api/v1/endpoints/dashboard.py
+++ b/backend/api/v1/endpoints/dashboard.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/metrics")
+def metrics() -> dict[str, float]:
+    return {"total_leads": 0, "average_check": 0.0}

--- a/backend/services/ai.py
+++ b/backend/services/ai.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+import numpy as np
+import openai
+
+try:  # optional dependency
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover
+    faiss = None
+
+INDEX_PATH = os.environ.get("RAG_INDEX_PATH", "rag_index.faiss")
+META_PATH = os.environ.get("RAG_META_PATH", "rag_index.meta")
+
+_rag_index = None
+_rag_texts: List[str] = []
+
+
+def load_rag_index() -> None:
+    """Load FAISS index from disk if available."""
+    global _rag_index, _rag_texts
+    if faiss is None:
+        return
+    if os.path.exists(INDEX_PATH):
+        _rag_index = faiss.read_index(INDEX_PATH)
+    if os.path.exists(META_PATH):
+        with open(META_PATH, "r", encoding="utf-8") as f:
+            _rag_texts = json.load(f)
+
+
+def auto_segment_lead(lead: Dict[str, Any]) -> str:
+    """Simple heuristic-based lead segmentation."""
+    price = lead.get("final_price", 0)
+    if price >= 1_000_000:
+        return "VIP"
+    if price >= 500_000:
+        return "Premium"
+    return "Standard"
+
+
+def generate_followup_questions(lead: Dict[str, Any], k: int = 3) -> List[str]:
+    """Suggest follow-up questions based on missing fields."""
+    questions: List[str] = []
+    answers = lead.get("answers_details", {}) or {}
+    if "budget" not in answers:
+        questions.append("Каков ваш целевой бюджет?")
+    if "timeline" not in answers:
+        questions.append("В какие сроки планируете запуск?")
+    if "needs" not in answers:
+        questions.append("Какие основные потребности у вашего бизнеса?")
+    return questions[:k]
+
+
+def predict_ltv(lead: Dict[str, Any]) -> float:
+    """Very naive LTV prediction based on final price."""
+    price = lead.get("final_price", 0)
+    return round(price * 3.5, 2)
+
+
+# initialize RAG index on import
+load_rag_index()

--- a/frontend/src/components/AIInsights.vue
+++ b/frontend/src/components/AIInsights.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="ai-insights">
+    <h2>AI-insights</h2>
+    <div v-if="loading">Загрузка...</div>
+    <div v-else-if="insights">
+      <p><strong>Сегмент:</strong> {{ insights.segment }}</p>
+      <p><strong>Что спросить дальше:</strong></p>
+      <ul>
+        <li v-for="q in insights.next_questions" :key="q">{{ q }}</li>
+      </ul>
+      <p><strong>Прогноз LTV:</strong> {{ formatCurrency(insights.ltv_prediction) }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import aiService from '@/services/ai.service.js'
+
+const insights = ref(null)
+const loading = ref(true)
+
+const fetchInsights = async () => {
+  try {
+    const payload = { final_price: 100000, answers_details: {} }
+    const response = await aiService.getInsights(payload)
+    insights.value = response.data
+  } finally {
+    loading.value = false
+  }
+}
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB' }).format(value)
+}
+
+onMounted(fetchInsights)
+</script>
+
+<style scoped>
+.ai-insights {
+  margin-top: 20px;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+}
+.ai-insights ul {
+  list-style: disc;
+  margin-left: 20px;
+}
+</style>

--- a/frontend/src/services/ai.service.js
+++ b/frontend/src/services/ai.service.js
@@ -1,0 +1,9 @@
+import apiClient from './apiClient.js'
+
+class AIService {
+  getInsights(payload) {
+    return apiClient.post('/api/v1/ai/insights', payload)
+  }
+}
+
+export default new AIService()

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -15,12 +15,15 @@
         <div class="metric-label">Средний чек</div>
       </div>
     </div>
+
+    <AIInsights />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
-import dashboardService from '@/services/dashboard.service.js';
+import { ref, onMounted } from 'vue'
+import dashboardService from '@/services/dashboard.service.js'
+import AIInsights from '@/components/AIInsights.vue'
 
 const metrics = ref(null);
 const loading = ref(true);

--- a/scripts/build_rag_index.py
+++ b/scripts/build_rag_index.py
@@ -1,0 +1,52 @@
+"""Utility to build or update a simple vector index for RAG."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import openai
+
+try:
+    import faiss  # type: ignore
+except Exception as exc:  # pragma: no cover
+    raise SystemExit("faiss library is required: %s" % exc)
+
+
+def load_texts(data_dir: Path) -> List[str]:
+    texts: List[str] = []
+    for path in data_dir.glob("*.txt"):
+        texts.append(path.read_text(encoding="utf-8"))
+    return texts
+
+
+def build_index(texts: List[str], out_path: Path) -> None:
+    embeddings = []
+    for txt in texts:
+        resp = openai.Embedding.create(model="text-embedding-3-small", input=txt)
+        embeddings.append(resp["data"][0]["embedding"])
+    matrix = np.array(embeddings).astype("float32")
+    index = faiss.IndexFlatL2(matrix.shape[1])
+    index.add(matrix)
+    faiss.write_index(index, str(out_path))
+    with open(str(out_path) + ".meta", "w", encoding="utf-8") as f:
+        json.dump(texts, f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build RAG vector index")
+    parser.add_argument("data_dir", type=Path, help="Directory with .txt documents")
+    parser.add_argument("out", type=Path, help="Path to save FAISS index")
+    args = parser.parse_args()
+
+    texts = load_texts(args.data_dir)
+    if not texts:
+        raise SystemExit("No .txt files found in data directory")
+    build_index(texts, args.out)
+    print(f"Index with {len(texts)} documents written to {args.out}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- implement AI service for lead segmentation, follow-up question generation, and LTV prediction
- expose AI insight endpoints and hook them into API router
- add script and loader for RAG index plus frontend AI-insights block

## Testing
- `npm run lint`
- `python -m py_compile backend/services/ai.py backend/api/v1/endpoints/ai.py backend/api/v1/endpoints/api.py scripts/build_rag_index.py`


------
https://chatgpt.com/codex/tasks/task_b_6895edd1e0e483318195aa4f4dd02780