### PR TITLE
Add dashboard metrics endpoint and import FastAPI router

### DIFF
--- a/backend/api/v1/endpoints/api.py
+++ b/backend/api/v1/endpoints/api.py
@@ -1,8 +1,12 @@
-# backend/app/api/v1/endpoints/api.py  (добавление роутера)
-from app.api.v1.endpoints import quizzes, leads, dashboard, estimate
+"""Main API router aggregating individual endpoint routers."""
+
+from fastapi import APIRouter
+
+from app.api.v1.endpoints import dashboard, estimate, leads, quizzes
 
 api_router = APIRouter()
 api_router.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])
 api_router.include_router(leads.router, prefix="/leads", tags=["leads"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(estimate.router, prefix="/estimate", tags=["estimate"])
+

--- a/backend/api/v1/endpoints/dashboard.py
+++ b/backend/api/v1/endpoints/dashboard.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.models import lead as lead_model
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+def get_metrics(
+    db: Session = Depends(deps.get_db),
+    tenant_id: str = Depends(deps.get_tenant_id),
+):
+    """Return simple dashboard metrics for the current tenant."""
+    total_leads, average_check = db.query(
+        func.count(lead_model.Lead.id),
+        func.coalesce(func.avg(lead_model.Lead.final_price), 0.0),
+    ).filter(lead_model.Lead.tenant_id == tenant_id).one()
+
+    return {"total_leads": total_leads, "average_check": average_check}
+


### PR DESCRIPTION
## Summary
- import APIRouter into main API router and include dashboard routes
- add dashboard metrics endpoint returning total leads and average check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895eddc3488833197f7506706d88ad9