### PR TITLE
Use entrypoint script for backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     container_name: leadconverter-pro-backend-1
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    entrypoint: /app/entrypoint.sh
     volumes:
       - ./backend:/app
     ports:


### PR DESCRIPTION
## Summary
- ensure backend service runs /app/entrypoint.sh instead of overriding with a uvicorn command

## Testing
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml valid')
PY`
- `PATH=/tmp/fakebin:$PATH sh backend/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_b_6895eddf28cc8331a8827c474eae2199