### PR TITLE
Setup Alembic migrations

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# Add the repository root to the path to import the application modules
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if BASE_DIR not in sys.path:
+    sys.path.append(BASE_DIR)
+
+# Alias 'backend' package as 'app' for imports like 'from app.database import Base'
+import backend as app_module  # type: ignore
+sys.modules['app'] = app_module
+
+from app.core.config import settings  # noqa: E402
+from app.database import Base  # noqa: E402
+
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Override the sqlalchemy.url value with the one from application settings
+config.set_main_option('sqlalchemy.url', settings.DATABASE_URL)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    context.configure(
+        url=config.get_main_option('sqlalchemy.url'),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ''}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,68 @@
+"""initial tables
+
+Revision ID: 0001_initial
+Revises: 
+Create Date: 2024-06-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001_initial'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'quizzes',
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('tenant_id', sa.String(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True)
+    )
+    op.create_index('ix_quizzes_tenant_id', 'quizzes', ['tenant_id'])
+    op.create_index('ix_quizzes_title', 'quizzes', ['title'])
+
+    op.create_table(
+        'questions',
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('text', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('question_type', sa.String(), nullable=True),
+        sa.Column('order', sa.Integer(), nullable=False),
+        sa.Column('quiz_id', sa.Integer(), sa.ForeignKey('quizzes.id'))
+    )
+
+    op.create_table(
+        'options',
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('text', sa.String(), nullable=False),
+        sa.Column('price_impact', sa.Float(), nullable=True),
+        sa.Column('order', sa.Integer(), nullable=False),
+        sa.Column('question_id', sa.Integer(), sa.ForeignKey('questions.id'))
+    )
+
+    op.create_table(
+        'leads',
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('tenant_id', sa.String(), nullable=False),
+        sa.Column('quiz_id', sa.Integer(), nullable=False),
+        sa.Column('client_email', sa.String(), nullable=False),
+        sa.Column('final_price', sa.Float(), nullable=False),
+        sa.Column('answers_details', sa.JSON(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now())
+    )
+    op.create_index('ix_leads_tenant_id', 'leads', ['tenant_id'])
+    op.create_index('ix_leads_client_email', 'leads', ['client_email'])
+
+def downgrade() -> None:
+    op.drop_index('ix_leads_client_email', table_name='leads')
+    op.drop_index('ix_leads_tenant_id', table_name='leads')
+    op.drop_table('leads')
+    op.drop_table('options')
+    op.drop_table('questions')
+    op.drop_index('ix_quizzes_title', table_name='quizzes')
+    op.drop_index('ix_quizzes_tenant_id', table_name='quizzes')
+    op.drop_table('quizzes')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ pydantic-settings==2.2.1
 # --- Database ---
 sqlalchemy==2.0.30
 psycopg2-binary==2.9.9
+alembic==1.13.1
 
 # --- Security ---
 passlib[bcrypt]==1.7.4


### PR DESCRIPTION
## Summary
- add Alembic configuration tied to app settings
- include initial database schema migration

## Testing
- `pip install alembic==1.13.1`
- `cd backend && SECRET_KEY=test DATABASE_URL=sqlite:///./test.db alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_b_6895ede091b083319b159624cffa15e6