### PR TITLE
feat: enable tenant isolation with RLS

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,8 +1,7 @@
 from typing import Generator
 from fastapi import Header, Depends
-from sqlalchemy import text
 
-from app.database import SessionLocal
+from app.database import get_db as db_session
 
 def get_tenant_id(x_tenant_id: str = Header(...)) -> str:
     """Получить идентификатор арендатора из заголовка."""
@@ -10,12 +9,5 @@ def get_tenant_id(x_tenant_id: str = Header(...)) -> str:
 
 
 def get_db(tenant_id: str = Depends(get_tenant_id)) -> Generator:
-    """
-    Зависимость, предоставляющая сессию базы данных и устанавливающая контекст арендатора.
-    """
-    try:
-        db = SessionLocal()
-        db.execute(text("SET app.tenant_id = :tenant_id"), {"tenant_id": tenant_id})
-        yield db
-    finally:
-        db.close()
+    """Предоставляет сессию БД для указанного tenant_id."""
+    yield from db_session(tenant_id)

--- a/backend/api/v1/endpoints/estimate.py
+++ b/backend/api/v1/endpoints/estimate.py
@@ -13,6 +13,7 @@ router = APIRouter()
 async def recalc_estimate(
     payload: EstimateRequest,
     db: Session = Depends(deps.get_db),
+    tenant_id: str = Depends(deps.get_tenant_id),
 ) -> EstimateResponse:
-    cost = await run_in_threadpool(calculate_estimate, db, payload)
+    cost = await run_in_threadpool(calculate_estimate, db, payload, tenant_id)
     return EstimateResponse(estimated_cost=cost)

--- a/backend/crud/crud_lead.py
+++ b/backend/crud/crud_lead.py
@@ -17,12 +17,26 @@ class CRUDLead:
 
         # 1. Получаем все опции, которые выбрал пользователь, одним запросом
         chosen_option_ids = [answer.option_id for answer in obj_in.answers if answer.option_id]
-        chosen_options = db.query(quiz_model.Option).filter(quiz_model.Option.id.in_(chosen_option_ids)).all()
+        chosen_options = (
+            db.query(quiz_model.Option)
+            .filter(
+                quiz_model.Option.id.in_(chosen_option_ids),
+                quiz_model.Option.tenant_id == tenant_id,
+            )
+            .all()
+        )
         options_map = {option.id: option for option in chosen_options}
 
         # 2. Обрабатываем ответы
         for answer in obj_in.answers:
-            question = db.query(quiz_model.Question).filter(quiz_model.Question.id == answer.question_id).first()
+            question = (
+                db.query(quiz_model.Question)
+                .filter(
+                    quiz_model.Question.id == answer.question_id,
+                    quiz_model.Question.tenant_id == tenant_id,
+                )
+                .first()
+            )
             if not question:
                 continue
 

--- a/backend/crud/crud_quiz.py
+++ b/backend/crud/crud_quiz.py
@@ -37,14 +37,16 @@ class CRUDQuiz:
                     text=question_in.text,
                     description=question_in.description,
                     question_type=question_in.question_type,
-                    order=question_in.order
+                    order=question_in.order,
+                    tenant_id=tenant_id,
                 )
                 if question_in.options:
                     for option_in in question_in.options:
                         db_option = Option(
                             text=option_in.text,
                             price_impact=option_in.price_impact,
-                            order=option_in.order
+                            order=option_in.order,
+                            tenant_id=tenant_id,
                         )
                         db_question.options.append(db_option)
                 db_quiz.questions.append(db_question)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,20 +1,52 @@
 import os
-from sqlalchemy import create_engine
+from typing import Generator
+
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/leadconverter")
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql://user:password@localhost/leadconverter"
+)
 
-engine = create_engine(DATABASE_URL)
+# Включаем поддержку RLS на уровне соединения
+engine = create_engine(
+    DATABASE_URL, connect_args={"options": "-c row_security=on"}
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
-def get_db():
+
+def get_db(tenant_id: str) -> Generator:
+    """Возвращает сессию БД с установленным tenant_id."""
     db = SessionLocal()
+    db.execute(text("SET app.tenant_id = :tenant_id"), {"tenant_id": tenant_id})
     try:
         yield db
     finally:
         db.close()
+
+
+def init_db() -> None:
+    """Создание таблиц и настройка политик RLS."""
+    Base.metadata.create_all(bind=engine)
+    tables = ["leads", "quizzes", "questions", "options"]
+    with engine.begin() as conn:
+        for table in tables:
+            conn.execute(text(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"))
+            conn.execute(text(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"))
+            conn.execute(text(f"DROP POLICY IF EXISTS tenant_isolation ON {table}"))
+            conn.execute(
+                text(
+                    f"""
+                    CREATE POLICY tenant_isolation ON {table}
+                    USING (tenant_id = current_setting('app.tenant_id')::text)
+                    WITH CHECK (tenant_id = current_setting('app.tenant_id')::text)
+                    """
+                )
+            )
+
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,10 @@ from fastapi import FastAPI
 
 from app.api.v1.endpoints.api import api_router
 from app.api.v1.endpoints import log_summary
+from app.database import init_db
 
 load_dotenv()
+init_db()
 
 app = FastAPI(
     title="LeadConverter Pro API",

--- a/backend/models/lead.py
+++ b/backend/models/lead.py
@@ -1,11 +1,13 @@
-from sqlalchemy import Column, Integer, String, Float, JSON, DateTime, func
+from sqlalchemy import Column, Integer, String, Float, JSON, DateTime, func, text
 from app.database import Base
 
 class Lead(Base):
     __tablename__ = "leads"
 
     id = Column(Integer, primary_key=True, index=True)
-    tenant_id = Column(String, index=True, nullable=False)
+    tenant_id = Column(
+        String, index=True, nullable=False, server_default=text("current_setting('app.tenant_id')")
+    )
     quiz_id = Column(Integer, nullable=False)
     client_email = Column(String, index=True, nullable=False)
     final_price = Column(Float, nullable=False)

--- a/backend/models/quiz.py
+++ b/backend/models/quiz.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Text
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, Text, text
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -6,7 +6,9 @@ from app.database import Base
 class Quiz(Base):
     __tablename__ = "quizzes"
     id = Column(Integer, primary_key=True, index=True)
-    tenant_id = Column(String, index=True, nullable=False)
+    tenant_id = Column(
+        String, index=True, nullable=False, server_default=text("current_setting('app.tenant_id')")
+    )
     title = Column(String, index=True, nullable=False)
     description = Column(Text, nullable=True)
     questions = relationship("Question", back_populates="quiz", cascade="all, delete-orphan")
@@ -14,6 +16,9 @@ class Quiz(Base):
 class Question(Base):
     __tablename__ = "questions"
     id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(
+        String, index=True, nullable=False, server_default=text("current_setting('app.tenant_id')")
+    )
     text = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     question_type = Column(String, default="single-choice")
@@ -25,6 +30,9 @@ class Question(Base):
 class Option(Base):
     __tablename__ = "options"
     id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(
+        String, index=True, nullable=False, server_default=text("current_setting('app.tenant_id')")
+    )
     text = Column(String, nullable=False)
     price_impact = Column(Float, default=0.0)
     order = Column(Integer, nullable=False)

--- a/backend/services/estimate_service.py
+++ b/backend/services/estimate_service.py
@@ -3,14 +3,18 @@ from sqlalchemy.orm import Session
 from app.models import quiz as quiz_model
 from app.schemas.estimate import EstimateRequest
 
-def calculate_estimate(db: Session, payload: EstimateRequest) -> float:
+
+def calculate_estimate(db: Session, payload: EstimateRequest, tenant_id: str) -> float:
     base_price = 0.0
     area_multiplier = 1.0
 
     chosen_option_ids = [a.option_id for a in payload.answers if a.option_id]
     options = (
         db.query(quiz_model.Option)
-        .filter(quiz_model.Option.id.in_(chosen_option_ids))
+        .filter(
+            quiz_model.Option.id.in_(chosen_option_ids),
+            quiz_model.Option.tenant_id == tenant_id,
+        )
         .all()
     )
     options_map = {opt.id: opt for opt in options}
@@ -18,7 +22,10 @@ def calculate_estimate(db: Session, payload: EstimateRequest) -> float:
     for ans in payload.answers:
         question = (
             db.query(quiz_model.Question)
-            .filter(quiz_model.Question.id == ans.question_id)
+            .filter(
+                quiz_model.Question.id == ans.question_id,
+                quiz_model.Question.tenant_id == tenant_id,
+            )
             .first()
         )
         if not question:

--- a/scripts/setup_rls.py
+++ b/scripts/setup_rls.py
@@ -7,20 +7,17 @@ from app.database import engine
 def main() -> None:
     """Create RLS policies for tenant isolation on core tables."""
     with engine.begin() as conn:
-        conn.execute(text("ALTER TABLE leads ENABLE ROW LEVEL SECURITY"))
-        conn.execute(text("ALTER TABLE leads FORCE ROW LEVEL SECURITY"))
-        conn.execute(
-            text(
-                "CREATE POLICY IF NOT EXISTS tenant_isolation_leads ON leads USING (tenant_id = current_setting('app.tenant_id')::text)"
+        for table in ["leads", "quizzes", "questions", "options"]:
+            conn.execute(text(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"))
+            conn.execute(text(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"))
+            conn.execute(text(f"DROP POLICY IF EXISTS tenant_isolation_{table} ON {table}"))
+            conn.execute(
+                text(
+                    f"CREATE POLICY tenant_isolation_{table} ON {table} "
+                    f"USING (tenant_id = current_setting('app.tenant_id')::text) "
+                    f"WITH CHECK (tenant_id = current_setting('app.tenant_id')::text)"
+                )
             )
-        )
-        conn.execute(text("ALTER TABLE quizzes ENABLE ROW LEVEL SECURITY"))
-        conn.execute(text("ALTER TABLE quizzes FORCE ROW LEVEL SECURITY"))
-        conn.execute(
-            text(
-                "CREATE POLICY IF NOT EXISTS tenant_isolation_quizzes ON quizzes USING (tenant_id = current_setting('app.tenant_id')::text)"
-            )
-        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_rls_isolation.py
+++ b/scripts/test_rls_isolation.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+
+from app.database import get_db, init_db
+from app.models import Quiz
+
+@contextmanager
+def db_for(tenant: str):
+    gen = get_db(tenant)
+    db = next(gen)
+    try:
+        yield db
+    finally:
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+
+
+def main() -> None:
+    init_db()
+    with db_for("org1") as db:
+        db.add(Quiz(title="Quiz 1", description="", tenant_id="org1"))
+        db.commit()
+    with db_for("org2") as db:
+        db.add(Quiz(title="Quiz 2", description="", tenant_id="org2"))
+        db.commit()
+    with db_for("org1") as db:
+        titles = [q.title for q in db.query(Quiz).all()]
+        print("Org1 sees:", titles)
+    with db_for("org2") as db:
+        titles = [q.title for q in db.query(Quiz).all()]
+        print("Org2 sees:", titles)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add tenant-aware DB session and init policies for RLS
- attach tenant_id columns to all models and propagate header value through CRUD/API
- include isolation test script and initialize RLS on startup

## Testing
- `python -m py_compile backend/database.py backend/models/lead.py backend/models/quiz.py backend/api/deps.py backend/crud/crud_lead.py backend/crud/crud_quiz.py backend/api/v1/endpoints/estimate.py backend/services/estimate_service.py scripts/test_rls_isolation.py scripts/setup_rls.py backend/main.py`
- `PYTHONPATH=. python scripts/test_rls_isolation.py`

------
https://chatgpt.com/codex/tasks/task_b_6895edcfcae083319fbd7668d4436379