### PR TITLE
chore: expand env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,24 @@ DB_PORT=5432
 DB_USER=lcp_user
 DB_PASSWORD=lcp_password
 DB_NAME=lcp_db
+POSTGRES_SERVER=db
+POSTGRES_USER=lcp_user
+POSTGRES_PASSWORD=lcp_password
+POSTGRES_DB=lcp_db
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}/${POSTGRES_DB}
 
 # Backend (FastAPI) Settings
-SECRET_KEY=your_super_secret_key_32_chars_long_replace_me
+# Generate a 32-byte secret:
+#   openssl rand -hex 32
+SECRET_KEY=replace_with_generated_hex
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 BACKEND_CORS_ORIGINS=*
+
+# External Services
+STRIPE_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+OPENAI_API_KEY=
 
 # Frontend (Vue) Settings
 VITE_API_BASE_URL=http://backend:8000

--- a/.env.example.ini
+++ b/.env.example.ini
@@ -4,12 +4,22 @@ POSTGRES_USER=lcp_user
 POSTGRES_PASSWORD=lcp_password
 POSTGRES_DB=lcp_db
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}/${POSTGRES_DB}
+DB_HOST=db
+DB_PORT=5432
+DB_USER=lcp_user
+DB_PASSWORD=lcp_password
+DB_NAME=lcp_db
 
 # Backend (FastAPI) Settings
-SECRET_KEY=your_super_secret_key_32_chars_long # Замените на сгенерированный ключ (openssl rand -hex 32)
+SECRET_KEY=replace_with_generated_hex # генерируйте: openssl rand -hex 32
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 BACKEND_CORS_ORIGINS=*
+
+# External Services
+STRIPE_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+OPENAI_API_KEY=
 
 # Frontend (Vue) Settings
 VITE_API_BASE_URL=http://backend:8000


### PR DESCRIPTION
## Summary
- expand example env files with database connection URL and placeholders for Stripe and OpenAI keys

## Testing
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_b_6895f84078b08331b12b6968280b9a40