### PR TITLE
Refactor lead payload for quiz submissions

### DIFF
--- a/frontend/src/components/quiz/LeadFormModal.vue
+++ b/frontend/src/components/quiz/LeadFormModal.vue
@@ -1,23 +1,21 @@
 <script setup>
-import { ref } from 'vue';
 import { useQuizStore } from '../../stores/quiz.store.js';
 import logger from '../../utils/logger.js';
 
 const quizStore = useQuizStore();
-const email = ref('');
 
 function closeModal() {
   quizStore.closeLeadModal();
 }
 
-  async function handleSubmit() {
-    if (!email.value) {
-      quizStore.leadSubmissionError = "Email не может быть пустым.";
-      return;
-    }
-    logger.log('Submitting lead form', { email: email.value });
-    await quizStore.submitLead(email.value);
+async function handleSubmit() {
+  if (!quizStore.clientEmail) {
+    quizStore.leadSubmissionError = "Email не может быть пустым.";
+    return;
   }
+  logger.log('Submitting lead form', { email: quizStore.clientEmail });
+  await quizStore.submitLead();
+}
 </script>
 
 <template>
@@ -28,7 +26,7 @@ function closeModal() {
       <p>Введите ваш email, и мы отправим подробный расчет со всеми работами и материалами.</p>
       <form @submit.prevent="handleSubmit">
         <input
-          v-model="email"
+          v-model="quizStore.clientEmail"
           type="email"
           placeholder="your@email.com"
           required

--- a/frontend/src/services/lead.service.js
+++ b/frontend/src/services/lead.service.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 class LeadService {
   create(leadData) {
-    return apiClient.post('/api/v1/leads/', leadData);
+    return apiClient.post('/api/v1/leads/submit', leadData);
   }
 }
 


### PR DESCRIPTION
## Summary
- point LeadService to `/api/v1/leads/submit`
- build lead payload with `quiz_id`, `client_email`, and structured answers
- bind email input to store and submit directly from `LeadFormModal`

## Testing
- `npm run lint`
- `npm run build`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68961d2272588331aa516db1427c90c2