### PR TITLE
Refactor PDF generation to use Jinja template with logging

### DIFF
--- a/backend/services/pdf_generator.py
+++ b/backend/services/pdf_generator.py
@@ -1,12 +1,17 @@
+import logging
 import os
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from weasyprint import HTML
 from app.schemas.lead import LeadOut
 
-# Создаем папку для хранения смет, если ее нет
-PDF_STORAGE_PATH = "generated_pdfs"
-os.makedirs(PDF_STORAGE_PATH, exist_ok=True)
+logger = logging.getLogger(__name__)
+
+# Configurable storage path for generated PDFs
+PDF_STORAGE_PATH = Path(os.getenv("PDF_STORAGE_PATH", "generated_pdfs"))
+PDF_STORAGE_PATH.mkdir(parents=True, exist_ok=True)
+
+PDF_BASE_URL = os.getenv("PDF_BASE_URL")
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 _env = Environment(
@@ -14,71 +19,25 @@ _env = Environment(
     autoescape=select_autoescape(["html"]),
 )
 
+
 def generate_lead_pdf(lead_data: LeadOut) -> str:
-    """
-    Генерирует PDF-смету на основе данных лида и сохраняет ее.
-    Возвращает путь к файлу.
-    """
-    # Формируем красивый HTML-шаблон для сметы
-    html_content = f"""
-    <!DOCTYPE html>
-    <html lang="ru">
-    <head>
-        <meta charset="UTF-8">
-        <title>Смета по вашему проекту</title>
-        <style>
-            body {{ font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #333; }}
-            .container {{ width: 80%; margin: 0 auto; }}
-            .header {{ background-color: #4CAF50; color: white; padding: 20px; text-align: center; }}
-            .header h1 {{ margin: 0; }}
-            .content {{ padding: 20px; border: 1px solid #ddd; }}
-            .total {{ font-size: 24px; font-weight: bold; text-align: right; margin-top: 20px; }}
-            table {{ width: 100%; border-collapse: collapse; margin-top: 20px; }}
-            th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
-            th {{ background-color: #f2f2f2; }}
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div class="header">
-                <h1>LeadConverter Pro</h1>
-                <p>Предварительная смета на ремонт</p>
-            </div>
-            <div class="content">
-                <p><strong>Клиент:</strong> {lead_data.client_email}</p>
-                <h3>Детализация заказа:</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Вопрос</th>
-                            <th>Ваш ответ</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-    """
-    
-    for question, answer in lead_data.answers_details.items():
-        html_content += f"<tr><td>{question}</td><td>{answer}</td></tr>"
+    """Generate a PDF estimate for a lead.
 
-    html_content += f"""
-                    </tbody>
-                </table>
-                <div class="total">
-                    Итоговая стоимость: {lead_data.final_price:,.2f} RUB
-                </div>
-            </div>
-        </div>
-    </body>
-    </html>
+    Returns the file path or a download URL if ``PDF_BASE_URL`` is set.
     """
+    template = _env.get_template("lead_pdf.html")
+    html_content = template.render(lead=lead_data)
 
-    # Генерируем PDF
     pdf_filename = f"lead_{lead_data.id}_estimate.pdf"
-    pdf_filepath = os.path.join(PDF_STORAGE_PATH, pdf_filename)
+    pdf_filepath = PDF_STORAGE_PATH / pdf_filename
 
-    HTML(string=html_content).write_pdf(pdf_filepath)
+    try:
+        HTML(string=html_content).write_pdf(str(pdf_filepath))
+        logger.info("PDF generated and saved: %s", pdf_filepath)
+    except OSError as exc:
+        logger.exception("Failed to write PDF: %s", exc)
+        raise
 
-    print(f"PDF сгенерирован и сохранен: {pdf_filepath}")
-
-    # В реальном приложении здесь может быть URL для скачивания
-    return pdf_filepath
+    if PDF_BASE_URL:
+        return f"{PDF_BASE_URL.rstrip('/')}/{pdf_filename}"
+    return str(pdf_filepath)

--- a/backend/templates/lead_pdf.html
+++ b/backend/templates/lead_pdf.html
@@ -22,7 +22,7 @@
             <p>Предварительная смета на ремонт</p>
         </div>
         <div class="content">
-            <p><strong>Клиент:</strong> {{ lead.client_email }}</p>
+            <p><strong>Клиент:</strong> {{ lead.client_email | e }}</p>
             <h3>Детализация заказа:</h3>
             <table>
                 <thead>
@@ -33,7 +33,7 @@
                 </thead>
                 <tbody>
                     {% for question, answer in lead.answers_details.items() %}
-                    <tr><td>{{ question }}</td><td>{{ answer }}</td></tr>
+                    <tr><td>{{ question | e }}</td><td>{{ answer | e }}</td></tr>
                     {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Render lead estimates from a Jinja2 template with autoescaping
- Add configurable PDF storage, logging, and I/O error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68961d236cb883319aeb2a2f5e61b310