### PR TITLE
Refactor lead price calculation into dedicated service

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -3,6 +3,7 @@ from fastapi import Header, Depends
 from sqlalchemy import text
 
 from backend.database import SessionLocal
+from app.services.lead_calculator import LeadCalculator
 
 def get_tenant_id(x_tenant_id: str = Header(...)) -> str:
     """Получить идентификатор арендатора из заголовка."""
@@ -23,3 +24,8 @@ def get_db(tenant_id: str = Depends(get_tenant_id)) -> Generator:
         raise
     finally:
         db.close()
+
+
+def get_lead_calculator() -> LeadCalculator:
+    """Provide LeadCalculator service instance."""
+    return LeadCalculator()

--- a/backend/api/v1/endpoints/estimate.py
+++ b/backend/api/v1/endpoints/estimate.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import Session
 
 from ... import deps
 from ...schemas.estimate import EstimateRequest, EstimateResponse
-from backend.services.estimate_service import calculate_estimate
+from app.services.lead_calculator import LeadCalculator
+from app.services.estimate_service import calculate_estimate
 
 router = APIRouter()
 
@@ -13,6 +14,7 @@ router = APIRouter()
 async def recalc_estimate(
     payload: EstimateRequest,
     db: Session = Depends(deps.get_db),
+    calculator: LeadCalculator = Depends(deps.get_lead_calculator),
 ) -> EstimateResponse:
-    cost = await run_in_threadpool(calculate_estimate, db, payload)
-    return EstimateResponse(estimated_cost=cost)
+    price = await run_in_threadpool(calculate_estimate, db, payload, calculator)
+    return EstimateResponse(estimated_cost=price)

--- a/backend/api/v1/endpoints/leads.py
+++ b/backend/api/v1/endpoints/leads.py
@@ -4,7 +4,8 @@ from typing import List, Any
 
 from app import crud, schemas
 from app.api import deps
-from app.services import pdf_generator  # Импортируем наш новый сервис
+from app.services import pdf_generator
+from app.services.lead_calculator import LeadCalculator
 
 router = APIRouter()
 
@@ -14,26 +15,20 @@ def submit_lead(
     db: Session = Depends(deps.get_db),
     tenant_id: str = Depends(deps.get_tenant_id),
     lead_in: schemas.lead.LeadCreateIn,
+    calculator: LeadCalculator = Depends(deps.get_lead_calculator),
 ) -> Any:
     """
     Принять ответы квиза, рассчитать стоимость, сохранить лид и сгенерировать PDF.
     Это основной эндпоинт для фронтенда.
     """
-    # 1. Создаем лид с расчетом цены через CRUD
     created_lead = crud.lead.create_with_calculation(
-        db=db, obj_in=lead_in, tenant_id=tenant_id
+        db=db, obj_in=lead_in, tenant_id=tenant_id, calculator=calculator
     )
 
-    # 2. Преобразуем созданный объект в Pydantic-схему для ответа
     lead_out_data = schemas.lead.LeadOut.model_validate(created_lead)
 
-    # 3. Генерируем PDF и получаем путь к нему
-    # В будущем здесь можно будет вернуть URL для скачивания
     pdf_path = pdf_generator.generate_lead_pdf(lead_out_data)
-    lead_out_data.pdf_url = pdf_path # Добавляем путь в ответ API
-
-    # 4. Здесь же можно будет добавить отправку уведомлений в Telegram/Email
-    # notification_service.send_new_lead_notification(lead_out_data)
+    lead_out_data.pdf_url = pdf_path
 
     return lead_out_data
 

--- a/backend/services/estimate_service.py
+++ b/backend/services/estimate_service.py
@@ -1,38 +1,17 @@
-# backend/app/services/estimate_service.py
+"""Wrapper around lead calculator to compute cost estimates."""
+import logging
 from sqlalchemy.orm import Session
-from app.models import quiz as quiz_model
+
 from app.schemas.estimate import EstimateRequest
+from app.services.lead_calculator import LeadCalculator
 
-def calculate_estimate(db: Session, payload: EstimateRequest) -> float:
-    base_price = 0.0
-    area_multiplier = 1.0
+logger = logging.getLogger(__name__)
 
-    chosen_option_ids = [a.option_id for a in payload.answers if a.option_id]
-    options = (
-        db.query(quiz_model.Option)
-        .filter(quiz_model.Option.id.in_(chosen_option_ids))
-        .all()
-    )
-    options_map = {opt.id: opt for opt in options}
-
-    question_ids = [a.question_id for a in payload.answers]
-    questions = (
-        db.query(quiz_model.Question)
-        .filter(quiz_model.Question.id.in_(question_ids))
-        .all()
-    )
-    questions_map = {q.id: q for q in questions}
-
-    for ans in payload.answers:
-        question = questions_map.get(ans.question_id)
-        if not question:
-            continue
-        if question.question_type == "slider":
-            try:
-                area_multiplier = float(ans.value)
-            except (ValueError, TypeError):
-                area_multiplier = 1.0
-        elif ans.option_id in options_map:
-            base_price += options_map[ans.option_id].price_impact
-
-    return base_price * area_multiplier
+def calculate_estimate(
+    db: Session, payload: EstimateRequest, calculator: LeadCalculator | None = None
+) -> float:
+    """Calculate estimated cost using LeadCalculator service."""
+    calc = calculator or LeadCalculator()
+    price, _ = calc.calculate(db, payload.answers)
+    logger.debug("Estimate calculated: %s", price)
+    return price

--- a/backend/services/lead_calculator.py
+++ b/backend/services/lead_calculator.py
@@ -1,0 +1,81 @@
+import logging
+from typing import Dict, Iterable, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models import quiz as quiz_model
+from app.schemas.lead import LeadAnswerIn
+
+logger = logging.getLogger(__name__)
+
+class LeadCalculationError(Exception):
+    """Raised when lead price calculation fails."""
+
+class LeadCalculator:
+    """Service responsible for calculating lead prices."""
+
+    def __init__(self, log: logging.Logger | None = None) -> None:
+        self.logger = log or logger
+
+    def calculate(
+        self, db: Session, answers: Iterable[LeadAnswerIn]
+    ) -> Tuple[float, Dict[str, str]]:
+        """Calculate final price and answer details.
+
+        Args:
+            db: SQLAlchemy session.
+            answers: Iterable of LeadAnswerIn provided by user.
+
+        Returns:
+            Tuple containing final price and mapping of question text to answer text.
+        """
+        base_price = 0.0
+        area_multiplier = 1.0
+        answers_details: Dict[str, str] = {}
+
+        try:
+            self.logger.debug("Starting calculation for %d answers", len(list(answers)))
+        except TypeError:
+            # in case answers is a generator consumed later we convert to list once
+            answers = list(answers)
+            self.logger.debug("Starting calculation for %d answers", len(answers))
+
+        try:
+            chosen_option_ids = [a.option_id for a in answers if a.option_id]
+            options = (
+                db.query(quiz_model.Option)
+                .filter(quiz_model.Option.id.in_(chosen_option_ids))
+                .all()
+            )
+            options_map = {opt.id: opt for opt in options}
+
+            question_ids = [a.question_id for a in answers]
+            questions = (
+                db.query(quiz_model.Question)
+                .filter(quiz_model.Question.id.in_(question_ids))
+                .all()
+            )
+            questions_map = {q.id: q for q in questions}
+
+            for ans in answers:
+                question = questions_map.get(ans.question_id)
+                if not question:
+                    continue
+                if question.question_type == "slider":
+                    try:
+                        area_multiplier = float(ans.value)
+                        answers_details[question.text] = f"{area_multiplier} м²"
+                    except (ValueError, TypeError) as e:
+                        self.logger.warning("Invalid area value %r: %s", ans.value, e)
+                        area_multiplier = 1.0
+                elif ans.option_id in options_map:
+                    option = options_map[ans.option_id]
+                    base_price += option.price_impact
+                    answers_details[question.text] = option.text
+
+            final_price = base_price * area_multiplier
+            self.logger.info("Calculated price: %s", final_price)
+            return final_price, answers_details
+        except Exception as exc:
+            self.logger.exception("Failed to calculate price")
+            raise LeadCalculationError from exc

--- a/backend/tests/test_lead_calculator.py
+++ b/backend/tests/test_lead_calculator.py
@@ -1,0 +1,104 @@
+import logging
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+
+# Create lightweight quiz models for testing
+class _Column:
+    def in_(self, _):
+        return self
+
+
+class Option:
+    id = _Column()
+
+    def __init__(self, id: int, text: str, price_impact: float):
+        self.id = id
+        self.text = text
+        self.price_impact = price_impact
+
+
+class Question:
+    id = _Column()
+
+    def __init__(self, id: int, text: str, question_type: str):
+        self.id = id
+        self.text = text
+        self.question_type = question_type
+
+quiz_module = types.ModuleType('quiz_module')
+quiz_module.Option = Option
+quiz_module.Question = Question
+
+backend_pkg = importlib.import_module('backend')
+sys.modules.setdefault('app', backend_pkg)
+app_models = types.ModuleType('app.models')
+app_models.quiz = quiz_module
+sys.modules['app.models'] = app_models
+sys.modules['app.models.quiz'] = quiz_module
+sys.modules.setdefault('app.schemas', importlib.import_module('backend.schemas'))
+
+from backend.services.lead_calculator import LeadCalculator
+from backend.schemas.lead import LeadAnswerIn
+
+
+class FakeQuery:
+    def __init__(self, data):
+        self.data = data
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self.data
+
+
+class FakeSession:
+    def __init__(self, options, questions):
+        self.options = options
+        self.questions = questions
+
+    def query(self, model):
+        if model is Option:
+            return FakeQuery(self.options)
+        if model is Question:
+            return FakeQuery(self.questions)
+        return FakeQuery([])
+
+
+def test_calculate_success():
+    q1 = Question(id=1, text="Floor", question_type="single-choice")
+    opt1 = Option(id=1, text="Tile", price_impact=100.0)
+    slider_q = Question(id=2, text="Area", question_type="slider")
+    session = FakeSession(options=[opt1], questions=[q1, slider_q])
+
+    answers = [
+        LeadAnswerIn(question_id=q1.id, option_id=opt1.id),
+        LeadAnswerIn(question_id=slider_q.id, value="2"),
+    ]
+
+    calculator = LeadCalculator(log=logging.getLogger("test"))
+    price, details = calculator.calculate(session, answers)
+    assert price == 200.0
+    assert details[q1.text] == opt1.text
+    assert details[slider_q.text] == "2.0 м²"
+
+
+def test_calculate_invalid_area_caplog(caplog):
+    q1 = Question(id=1, text="Floor", question_type="single-choice")
+    opt1 = Option(id=1, text="Tile", price_impact=100.0)
+    slider_q = Question(id=2, text="Area", question_type="slider")
+    session = FakeSession(options=[opt1], questions=[q1, slider_q])
+
+    answers = [
+        LeadAnswerIn(question_id=q1.id, option_id=opt1.id),
+        LeadAnswerIn(question_id=slider_q.id, value="bad"),
+    ]
+
+    calculator = LeadCalculator()
+    with caplog.at_level(logging.WARNING):
+        price, details = calculator.calculate(session, answers)
+    assert price == 100.0
+    assert slider_q.text not in details
+    assert "Invalid area value" in caplog.text


### PR DESCRIPTION
## Summary
- add `LeadCalculator` service with logging and error handling
- use calculator in lead CRUD, estimate service, and API endpoints
- provide dependency injection and tests for calculator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68961d22bac883319caff15ac1239f9e